### PR TITLE
fix platform spelling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,9 @@
 ####################################################
-Linaro EDGE (LEDGE) reference platfrom documentation
+Linaro EDGE (LEDGE) reference platform documentation
 ####################################################
 
 The LEDGE documentation describes instructions to build, install
-and use varios features included in LEDGE linux reference platfrom. 
+and use varios features included in LEDGE linux reference platform.
 
 Contributing
 ============

--- a/source/chapter2-oe.rst
+++ b/source/chapter2-oe.rst
@@ -6,7 +6,7 @@ OpenEmbedded
 
 This chapter describes specific OpenEmbedded LEDGE build and run.
 
-Supported platfroms
+Supported platforms
 ===================
 - armv7/ledge-multi-armv7 (qemu, ti-am572x, stm32mp157c-dk2);
 - armv8/ledge-multi-armv8 (qemu, synquacer)

--- a/source/chapter3-debian.rst
+++ b/source/chapter3-debian.rst
@@ -6,7 +6,7 @@ Debian
 
 This chapter describes specific Debian LEDGE build and run.
 
-Supported platfroms
+Supported platforms
 ===================
  - armv7/armhf
  - armv8/arm64

--- a/source/chapter6-prebuilt-images.rst
+++ b/source/chapter6-prebuilt-images.rst
@@ -6,7 +6,7 @@ Prebuilt images
 
 This chapter describes how to download and use precompiled images
 
-Supported platfroms
+Supported platforms
 ===================
 - armv7/ledge-multi-armv7 (qemu)
 - armv8/ledge-multi-armv8 (qemu)

--- a/source/conf.py
+++ b/source/conf.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # Build configuration file, created by
-# sphinx-quickstart 
+# sphinx-quickstart
 #
 # This file is execfile()d with the current directory set to its
 # containing dir.
@@ -48,7 +48,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = 'LEDGE reference platfrom documentation'
+project = 'LEDGE reference platform documentation'
 copyright = '2020 Linaro Limited and Contributors'
 author = 'Linaro Limited and Contributors'
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -3,7 +3,7 @@
    SPDX-License-Identifier: CC-BY-SA-4.0
 
 ####################################################
-Linaro EDGE (LEDGE) reference platfrom documentation
+Linaro EDGE (LEDGE) reference platform documentation
 ####################################################
 
 Copyright © 2020 Linaro Limited and Contributors.


### PR DESCRIPTION
Several places were spelling 'platfrom' instead of platform

Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>