### PR TITLE
Fix a couple of spelling errors

### DIFF
--- a/dev-howto/chapter2-oe.rst
+++ b/dev-howto/chapter2-oe.rst
@@ -8,9 +8,9 @@ This chapter describes specific OpenEmbedded LEDGE build and run.
 
 Supported platforms
 ===================
-- armv7/ledge-multi-armv7 (qemu, ti-am572x, stm32mp157c-dk2);
-- armv8/ledge-multi-armv8 (qemu, synquacer)
-- x86-64 (qemu)
+- armv7/ledge-multi-armv7 (QEMU, ti-am572x, stm32mp157c-dk2);
+- armv8/ledge-multi-armv8 (QEMU, synquacer)
+- x86-64 (QEMU)
 
 Build steps
 ===========
@@ -33,7 +33,7 @@ armv7 family:
    MACHINE=ledge-multi-armv7 DISTRO=rpb source ./setup-environment build-rpb
    bitbake mc:qemuarm:ledge-iot mc:qemuarm:ledge-gateway ${FIRMWARE}
 
-Image files will apper under: armhf-glibc/deploy/images directory.
+Image files will appear under: armhf-glibc/deploy/images directory.
 
 Generated output will be:
 
@@ -171,7 +171,7 @@ Install and boot procedure
 OVMF firmware for different architectures can be downloaded from here: https://storage.kernelci.org/images/uefi/111bbcf87621/
 
 OE maintains script called 'runqemu'. This script automatically added to the path after source ./setup-environment is done. This script can be used to run
-qemu virtual machine with all required parameters to boot from image and run networking. Configuration file ledge-iot-ledge-qemuarm-*.qemuboot.conf is 
+QEMU virtual machine with all required parameters to boot from image and run networking. Configuration file ledge-iot-ledge-qemuarm-*.qemuboot.conf is 
 generated during the build process.
 
 Usage example usage:
@@ -304,7 +304,7 @@ OVMF:
       -cpu cortex-a57 -machine virt -nographic -net nic,model=virtio,macaddr=DE:AD:BE:EF:36:03 -net tap -m 1024 -monitor none \
       -bios ${OVMF} -drive id=disk0,file=${DISK},if=none,format=raw -device virtio-blk-device,drive=disk0 -m 4096 -smp 4 -nographic
 
-UBOOT:
+U-Boot:
 
 .. code-block:: bash
 

--- a/dev-howto/chapter4-internals.rst
+++ b/dev-howto/chapter4-internals.rst
@@ -11,7 +11,7 @@ Applications
 
 ledge-iot image package set is alignment with Fedora IoT package set. List of the packages can be found in bitbake recipe ( https://github.com/Linaro/meta-ledge/blob/zeus/meta-ledge-sw/recipes-samples/packagegroups/packagegroup-ledge-iot.bb ).
 
-ledge-gateway image includes minimal console image with Ostree and Docker updates support. ( https://github.com/Linaro/meta-ledge/blob/zeus/meta-ledge-sw/recipes-samples/images/ledge-gateway.bb )
+ledge-gateway image includes minimal console image with OStree and Docker updates support. ( https://github.com/Linaro/meta-ledge/blob/zeus/meta-ledge-sw/recipes-samples/images/ledge-gateway.bb )
 
 U-Boot hardening
 ================
@@ -21,8 +21,8 @@ Security is very important on EDGE nodes. Hardening and protecting the bootloade
 WIC image
 =========
 
-LEDGE WIC image for consists of 2 partiotions - ESP partition and linux rootfs partition. Disk image may have
-gpt lable type or may not, depends on varios hardware requirements.
+LEDGE WIC image for consists of 2 partitions - ESP partition and linux rootfs partition. Disk image may have
+gpt lable type or may not, depends on various hardware requirements.
 
 .. code-block:: bash
 
@@ -60,12 +60,12 @@ Where:
 Run LEDGE RP under QEMU
 =======================
 
-To run LEDGE RP under qemu runqemu OpenEmbedded script can be used or helper qemu script described in LEDGE User Guide document.
+To run LEDGE RP under QEMU the ``run_qemu.sh`` OpenEmbedded script can be used or the helper QEMU script as described in LEDGE User Guide document.
 
-QEMU with firmware TPM (fTMP) in OP-TEE, TF-A and U-Boot
+QEMU with firmware TPM (fTPM) in OP-TEE, TF-A and U-Boot
 ========================================================
 
-LEDGE patches default dtb for qemu with ftpm entry.
+LEDGE patches default dtb for QEMU with ftpm entry.
 
 
 .. code-block:: bash 

--- a/dev-howto/overview.rst
+++ b/dev-howto/overview.rst
@@ -12,13 +12,13 @@ LEDGE images are related to IoT and EDGE devices. It has advanced security featu
  - Secure UEFI boot
  - OP-TEE (Open Portable Trusted Execution Environment)
  - ARM trusted Firmware (AT-F)
- - Teanocore edk2 firmware or Uboot with UEFI mode support
- - fTMP (Firmware TPM driver with backend to OP-TEE)
+ - TianoCore EDK2 firmware or U-Boot with UEFI mode support
+ - fTPM (Firmware TPM driver with backend to OP-TEE)
  - Kernel image sign with certificate
  - Kernel modules sign
  - IMA/EVM for integrity user applications
- - Selinux
- - Containered isolation (docker)
+ - SElinux
+ - Containerized isolation (docker)
  - Advanced system update
 
 The LEDGE image consist of WIC image and firmware to boot this image on specific board or virtual machine.

--- a/user-guide/user-guide.rst
+++ b/user-guide/user-guide.rst
@@ -7,8 +7,8 @@ LEDGE RP USER GUIDE
 Introduction
 ============
 
-This document describes minimal steps to run LEDGE RP precompiled 
-images in virtual environment and play with it. It's recomended to
+This document describes minimal steps to run LEDGE RP precompiled
+images in virtual environment and play with it. It's recommended to
 walk over steps in this document for initial introduction with the
 Reference Platfrom.  Steps describe howto set up environment and
 run binaries and login to the shell. For more technical details and
@@ -18,9 +18,9 @@ Comments or change requests can be sent to team-ledge@linaro.org
 
 Supported platforms
 ===================
-- armv7/ledge-multi-armv7 (qemu)
-- armv8/ledge-multi-armv8 (qemu)
-- x86-64 (qemu)
+- armv7/ledge-multi-armv7 (QEMU)
+- armv8/ledge-multi-armv8 (QEMU)
+- x86-64 (QEMU)
 
 Steps
 ===========
@@ -28,7 +28,7 @@ Steps
 Download LEDGE RP binaries:
 --------------------------
 
-Download into current directory following files, depending on cpu architecture:
+Download into current directory following files, depending on CPU architecture:
 
 .. code-block:: bash
 
@@ -44,10 +44,10 @@ Download into current directory following files, depending on cpu architecture:
 | http://releases.linaro.org/components/ledge/
 
 
-Download qemu run script:
+Download QEMU run script:
 -------------------------
 
-Download helper script to run qemu with all required parameters.
+Download helper script to run QEMU with all required parameters.
 
 .. code-block:: bash
 
@@ -87,7 +87,7 @@ select one of the following options to run LEDGE RP under virtual machine:
 
     ./run_qemu.sh x86_64 ledge-iot-ledge-qemux86-64-<ts>.rootfs.wic ovmf
 
-You should see prints on console that firmware, booloader, linux boots.
+You should see prints on console that firmware, bootloader, linux boots.
 
 Login to the system
 -------------------


### PR DESCRIPTION
A couple of spelling fixes. I cannot find the same information in the git (master `rst`) as on the html page (gh-pages `index.html`), so I might or might not have fixed the ones that I saw when reading https://linaro.github.io/ledge-doc/. I'd imagine that `index.html` are generated from the different rst-files.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>